### PR TITLE
Remove $ parameter from init function

### DIFF
--- a/jquery.timeTo.js
+++ b/jquery.timeTo.js
@@ -19,7 +19,7 @@
         // globals
         factory(jQuery);
     }
-}(function ($) {
+}(function () {
 
     var methods = {
         start: function(sec){


### PR DESCRIPTION
When specifying the jQuery $ as a parameter to the init function it arrives as 'undefined' in jQuery v1.7.2.
Omitting the parameter works perfectly
