### PR TITLE
Fixed support for non-running init

### DIFF
--- a/jquery.timeTo.js
+++ b/jquery.timeTo.js
@@ -244,7 +244,7 @@
             }else if(data.start){
                 methods.start.call($this, data.seconds);
             }else {
-                methods.init.call($this, data.seconds);
+                init.call($this, data.seconds);
             }
         });
     };


### PR DESCRIPTION
It seems initialization fails when the start:false option is given. I tracked the bug to the line shown in the diff and changed it. It works for me now, but I would recommend that you look it over to ensure this change doesn't break anything else.
