### PR TITLE
reset call doesn't update counter clock (sometimes)

### DIFF
--- a/jquery.timeTo.js
+++ b/jquery.timeTo.js
@@ -48,7 +48,8 @@
             this.find('div').css({ backgroundPosition: 'left center' });
             this.find('ul').parent().removeClass('timeTo-alert');
 
-            if(typeof sec === "undefined") sec = data.value;
+            if(typeof sec === "undefined") { sec = data.value; }
+            if (data.vals) { data.vals = null; }
             init.call(this, sec);
         }
 


### PR DESCRIPTION
Set data.vals to null to force rebuild the counter clock
